### PR TITLE
Add lossless_into and lossy_into methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,7 @@ pub mod arithmetic;
 pub mod arithmetic_quantity_types;
 pub mod default_declarators;
 pub mod dimension_traits;
+pub mod lossy_into;
 #[cfg(feature = "alloc")]
 #[doc(hidden)]
 pub mod print;

--- a/src/lossy_into.rs
+++ b/src/lossy_into.rs
@@ -1,0 +1,146 @@
+pub trait LossyFrom<Source>: Sized {
+    fn lossy_from(source: Source) -> Self;
+}
+
+macro_rules! impl_lossy_from {
+    ($( $src:ty $(=> $dst_dir:ty)? $(= $dst_bi:ty)? ),* $(,)?) => {
+        $( impl_lossy_from!(@parse $src $(=> $dst_dir)? $(= $dst_bi)?); )*
+    };
+
+    // Identity
+    (@parse $ty:ty) => {
+        impl_lossy_from!(@generate $ty, $ty);
+    };
+
+    // One-way: f64 => f32
+    (@parse $src:ty => $dst:ty) => {
+        impl_lossy_from!(@generate $src, $dst);
+    };
+
+    // Bidirectional: f64 = f32
+    (@parse $t1:ty = $t2:ty) => {
+        impl_lossy_from!(@generate $t1, $t2);
+        impl_lossy_from!(@generate $t2, $t1);
+    };
+
+    (@generate $src:ty, $dst:ty) => {
+        impl LossyFrom<$src> for $dst {
+            #[inline]
+            fn lossy_from(n: $src) -> Self {
+                n as Self
+            }
+        }
+    };
+}
+
+impl_lossy_from![
+    f32, f64,
+    i8, i16, i32, i64, i128,
+    u8, u16, u32, u64, u128,
+    isize, usize,
+    f32 = f64,
+
+    // All possible combinations:
+    // f32 = i8,
+    // f32 = i16,
+    // f32 = i32,
+    // f32 = i64,
+    // f32 = i128,
+    // f32 = u8,
+    // f32 = u16,
+    // f32 = u32,
+    // f32 = u64,
+    // f32 = u128,
+    // f32 = isize,
+    // f32 = usize,
+    //
+    // f64 = i8,
+    // f64 = i16,
+    // f64 = i32,
+    // f64 = i64,
+    // f64 = i128,
+    // f64 = u8,
+    // f64 = u16,
+    // f64 = u32,
+    // f64 = u64,
+    // f64 = u128,
+    // f64 = isize,
+    // f64 = usize,
+    //
+    // i8 = i16,
+    // i8 = i32,
+    // i8 = i64,
+    // i8 = i128,
+    // i8 = u8,
+    // i8 = u16,
+    // i8 = u32,
+    // i8 = u64,
+    // i8 = u128,
+    // i8 = isize,
+    // i8 = usize,
+    //
+    // i16 = i32,
+    // i16 = i64,
+    // i16 = i128,
+    // i16 = u8,
+    // i16 = u16,
+    // i16 = u32,
+    // i16 = u64,
+    // i16 = u128,
+    // i16 = isize,
+    // i16 = usize,
+    //
+    // i32 = i64,
+    // i32 = i128,
+    // i32 = u8,
+    // i32 = u16,
+    // i32 = u32,
+    // i32 = u64,
+    // i32 = u128,
+    // i32 = isize,
+    // i32 = usize,
+    //
+    // i64 = i128,
+    // i64 = u8,
+    // i64 = u16,
+    // i64 = u32,
+    // i64 = u64,
+    // i64 = u128,
+    // i64 = isize,
+    // i64 = usize,
+    //
+    // i128 = u8,
+    // i128 = u16,
+    // i128 = u32,
+    // i128 = u64,
+    // i128 = u128,
+    // i128 = isize,
+    // i128 = usize,
+    //
+    // u8 = u16,
+    // u8 = u32,
+    // u8 = u64,
+    // u8 = u128,
+    // u8 = isize,
+    // u8 = usize,
+    //
+    // u16 = u32,
+    // u16 = u64,
+    // u16 = u128,
+    // u16 = isize,
+    // u16 = usize,
+    //
+    // u32 = u64,
+    // u32 = u128,
+    // u32 = isize,
+    // u32 = usize,
+    //
+    // u64 = u128,
+    // u64 = isize,
+    // u64 = usize,
+    //
+    // u128 = isize,
+    // u128 = usize,
+    //
+    // isize = usize,
+];

--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -63,6 +63,8 @@
 //! a brand (of the unit type `()`), so custom-branded quantities will not interoperate with default-declared
 //! quantities unless explicitly converted.
 
+use crate::lossy_into::LossyFrom;
+
 #[derive(PartialEq)]
 pub struct _2<const EXP: i16 = 0>;
 /// The base-3 scale exponent of a quantity.
@@ -407,6 +409,89 @@ impl<
             unsafe_value,
             _phantom: core::marker::PhantomData,
         }
+    }
+
+    /// Convert this quantity's underlying value to another numeric type using a
+    /// lossless conversion.
+    ///
+    /// This method preserves the quantity's scale, dimension, and brand while
+    /// converting its numeric representation.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # fn main() {
+    /// # use whippyunits::quantity;
+    /// // f32 -> f64
+    /// let distance = quantity!(1.0, m, f32);
+    /// _ = distance.lossless_into::<f64>();
+    ///
+    /// // u16 -> i32
+    /// let distance = quantity!(1, m, u16);
+    /// _ = distance.lossless_into::<i32>();
+    /// # }
+    /// ```
+    #[inline]
+    pub fn lossless_into<Dest: From<T>>(
+        self,
+    ) -> Quantity<
+        Scale<_2<SCALE_P2>, _3<SCALE_P3>, _5<SCALE_P5>, _Pi<SCALE_PI>>,
+        Dimension<
+            _M<MASS_EXPONENT>,
+            _L<LENGTH_EXPONENT>,
+            _T<TIME_EXPONENT>,
+            _I<CURRENT_EXPONENT>,
+            _Θ<TEMPERATURE_EXPONENT>,
+            _N<AMOUNT_EXPONENT>,
+            _J<LUMINOSITY_EXPONENT>,
+            _A<ANGLE_EXPONENT>,
+        >,
+        Dest,
+        Brand,
+    > {
+        Quantity::new(Dest::from(self.unsafe_value))
+    }
+
+    /// Convert this quantity's underlying value to another floating-point type using
+    /// a potentially lossy conversion.
+    ///
+    /// This method preserves the quantity's scale, dimension, and brand while
+    /// converting its numeric representation.
+    /// Lossy conversions are only implemented between `f32` and `f64`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # fn main() {
+    /// # use whippyunits::quantity;
+    /// // f64 -> f32 (possible information loss)
+    /// let distance = quantity!(1.0, m);
+    /// _ = distance.lossy_into::<f32>();
+    ///
+    /// // f32 -> f64 (no information loss, same as lossless_into)
+    /// let distance = quantity!(1.0, m, f32);
+    /// _ = distance.lossy_into::<f64>();
+    /// # }
+    /// ```
+    #[inline]
+    pub fn lossy_into<Dest: LossyFrom<T>>(
+        self,
+    ) -> Quantity<
+        Scale<_2<SCALE_P2>, _3<SCALE_P3>, _5<SCALE_P5>, _Pi<SCALE_PI>>,
+        Dimension<
+            _M<MASS_EXPONENT>,
+            _L<LENGTH_EXPONENT>,
+            _T<TIME_EXPONENT>,
+            _I<CURRENT_EXPONENT>,
+            _Θ<TEMPERATURE_EXPONENT>,
+            _N<AMOUNT_EXPONENT>,
+            _J<LUMINOSITY_EXPONENT>,
+            _A<ANGLE_EXPONENT>,
+        >,
+        Dest,
+        Brand,
+    > {
+        Quantity::new(Dest::lossy_from(self.unsafe_value))
     }
 
     /// Format this quantity in the specified unit

--- a/tests/test_lossy_into.rs
+++ b/tests/test_lossy_into.rs
@@ -1,0 +1,60 @@
+use whippyunits::{value, quantity, rescale};
+
+#[test]
+fn test_f64_to_f32() {
+    let temp_f64 = quantity!(300.0, K);
+    let temp_f32 = temp_f64.lossy_into::<f32>();
+    assert!((temp_f32.unsafe_value - 300.0_f32).abs() < 1e-3);
+}
+
+#[test]
+fn test_f32_to_f64() {
+    let temp_f32 = quantity!(300.0, K, f32);
+    let temp_f64 = temp_f32.lossy_into::<f64>();
+    assert!((temp_f64.unsafe_value - 300.0).abs() < 1e-5);
+}
+
+#[test]
+fn test_identity() {
+    let q = quantity!(123.456, m);
+    let q2 = q.lossy_into::<f64>();
+    assert_eq!(q.unsafe_value, q2.unsafe_value);
+}
+
+#[test]
+fn test_preserves_scale() {
+    let dist_km = quantity!(1.5, km);
+    let dist_km_f32 = dist_km.lossy_into::<f32>();
+    assert!((dist_km_f32.unsafe_value - 1.5_f32).abs() < 1e-5);
+}
+
+#[test]
+fn test_rescaled() {
+    let dist_km = quantity!(1.5, km);
+    let dist_m = rescale!(dist_km, m);
+    let dist_m_f32 = dist_m.lossy_into::<f32>();
+    assert!((dist_m_f32.unsafe_value - 1500.0_f32).abs() < 1e-5);
+}
+
+#[test]
+fn test_preserves_compound_dimension() {
+    let v_f64 = quantity!(9.8, m/s^2);
+    let v_f32 = v_f64.lossy_into::<f32>();
+    assert!((value!(v_f32, m/s^2, f32) - 9.8_f32).abs() < 1e-4);
+}
+
+#[test]
+fn test_chain() {
+    let q_f64 = quantity!(42.0, K);
+    let q_f32 = q_f64.lossy_into::<f32>();
+    let q_f64 = q_f32.lossy_into::<f64>();
+    assert!((q_f64.unsafe_value - 42.0_f64).abs() < 1e-4);
+}
+
+#[test]
+fn test_from_large_value() {
+    // 1e30 fits in f64 but loses significant bits in f32.
+    let large_f64 = quantity!(1e30_f64, kg);
+    let large_f32 = large_f64.lossy_into::<f32>();
+    assert!(value!(large_f32, kg, f32).is_finite());
+}


### PR DESCRIPTION
The first part of #5

Usage is the same as measures-rs:

```rust
let m = quantity!(6.9, kg, f32);
let m = m.lossless_into::<f64>(); // to f64
let m = m.lossy_into::<f32>();    // and back again
```

`impl_lossy_from` expands to 196 implementations if you add everything, I've just enabled identity and f32 <=> f64 for now.