### PR TITLE
add `amp` abbreviation; add compile errors on unrecognized unit names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-07-08
+
+### Added
+
+- `amp` as a recognized abbreviation/symbol for ampere (like `s` for second or `hr` for hour)
+- Compile-time validation of unit names/symbols in `unit!`, `quantity!`, and `value!` macros — previously, unrecognized units were silently treated as dimensionless; they now produce a `compile_error!` with fuzzy "Did you mean?" suggestions
+
 ## [0.2.4] - 2026-07-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "whippyunits"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "culit",
  "libm",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "whippyunits-core"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "whippyunits-proc-macros"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 authors = ["Oblarg"]
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ repository = "https://github.com/WhippyUnits/whippyunits-rs"
 
 [package]
 name = "whippyunits"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 authors = ["Oblarg"]
 license = "MIT OR Apache-2.0"
@@ -31,7 +31,7 @@ quote = { version = "1.0", optional = true }
 proc-macro2 = { version = "1.0", optional = true }
 syn = { version = "2.0", features = ["full"], optional = true }
 libm = "0.2"
-whippyunits-proc-macros = { path = "proc-macros", version = "0.2.4" }
+whippyunits-proc-macros = { path = "proc-macros", version = "0.2.5" }
 whippyunits-core = { path = "whippyunits-core", version = "0.2.1" }
 num-traits = "0.2"
 culit = "0.6.0"

--- a/proc-macros/Cargo.toml
+++ b/proc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whippyunits-proc-macros"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 authors.workspace = true
 license.workspace = true
@@ -18,4 +18,4 @@ proc-macro2 = "1.0"
 quote = "1.0"
 strsim = "0.11"
 syn = { version = "2.0", features = ["full"] }
-whippyunits-core = { path = "../whippyunits-core", version = "0.2.4" }
+whippyunits-core = { path = "../whippyunits-core", version = "0.2.5" }

--- a/proc-macros/src/quantity_macro.rs
+++ b/proc-macros/src/quantity_macro.rs
@@ -5,7 +5,7 @@ use syn::token::Comma;
 use syn::{Expr, Type};
 use whippyunits_core::{calculate_unit_conversion_factors, get_unit_info, Dimension, UnitExpr};
 
-use crate::utils::shared_utils::generate_unit_documentation_for_expr;
+use crate::utils::shared_utils::{generate_unit_documentation_for_expr, validate_known_units};
 
 /// Input for the quantity macro
 pub struct QuantityMacroInput {
@@ -48,6 +48,10 @@ impl Parse for QuantityMacroInput {
 
 impl QuantityMacroInput {
     pub fn expand(self) -> TokenStream {
+        if let Some(error) = validate_known_units(&self.unit_expr) {
+            return error;
+        }
+
         // Generate documentation structs for unit identifiers
         // For quantity! macro, use storage type for affine/nonstorage units
         let doc_structs = generate_unit_documentation_for_expr(&self.unit_expr, true);

--- a/proc-macros/src/unit_macro.rs
+++ b/proc-macros/src/unit_macro.rs
@@ -5,7 +5,7 @@ use syn::token::Comma;
 use syn::Type;
 use whippyunits_core::UnitExpr;
 
-use crate::utils::shared_utils::generate_unit_documentation_for_expr;
+use crate::utils::shared_utils::{generate_unit_documentation_for_expr, validate_known_units};
 
 /// Input for the unit macro
 pub struct UnitMacroInput {
@@ -44,6 +44,10 @@ impl Parse for UnitMacroInput {
 
 impl UnitMacroInput {
     pub fn expand(self) -> TokenStream {
+        if let Some(error) = validate_known_units(&self.unit_expr) {
+            return error;
+        }
+
         // Validate that no nonstorage units are used (strict mode requirement)
         if let Some(error_msg) = self.unit_expr.validate_strict() {
             return quote! {

--- a/proc-macros/src/utils/shared_utils.rs
+++ b/proc-macros/src/utils/shared_utils.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 /// Shared utilities for proc macros
 use syn::Ident;
-use whippyunits_core::{Dimension, SiPrefix, UnitExpr};
+use whippyunits_core::{Dimension, SiPrefix, UnitExpr, get_unit_info};
 
 /// Check if a unit name can be parsed as a valid Rust identifier
 /// This filters out units with unicode characters or other invalid identifier characters
@@ -412,4 +412,46 @@ pub fn generate_unit_documentation_for_expr(
     quote! {
         #(#doc_structs)*
     }
+}
+
+/// Validate that all unit identifiers in the expression are recognized.
+/// Returns `Some(compile_error!(...))` if any identifier is unknown, `None` if all are valid.
+pub fn validate_known_units(unit_expr: &UnitExpr) -> Option<TokenStream> {
+    use crate::utils::unit_suggestions::find_similar_units;
+
+    let mut identifiers = Vec::new();
+    collect_identifiers_from_expr(unit_expr, &mut identifiers);
+
+    for ident in &identifiers {
+        let name = ident.to_string();
+
+        if name == "dimensionless" || name == "power_of_10" {
+            continue;
+        }
+
+        if get_unit_info(&name).is_some() {
+            continue;
+        }
+
+        let suggestions = find_similar_units(&name, 0.7);
+        let error_message = if suggestions.is_empty() {
+            format!("Unknown unit '{}'. No similar units found.", name)
+        } else {
+            let suggestion_list = suggestions
+                .iter()
+                .map(|(s, _)| format!("'{}'", s))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(
+                "Unknown unit '{}'. Did you mean: {}?",
+                name, suggestion_list
+            )
+        };
+
+        return Some(quote! {
+            compile_error!(#error_message);
+        });
+    }
+
+    None
 }

--- a/proc-macros/src/value_macro.rs
+++ b/proc-macros/src/value_macro.rs
@@ -7,7 +7,7 @@ use whippyunits_core::{
     calculate_unit_conversion_factors, get_unit_info, Dimension, EvaluationMode, UnitExpr,
 };
 
-use crate::utils::shared_utils::generate_unit_documentation_for_expr;
+use crate::utils::shared_utils::{generate_unit_documentation_for_expr, validate_known_units};
 
 /// Input for the value! macro
 /// Syntax: value!(quantity, unit_expr) or value!(quantity, unit_expr, type) or value!(quantity, unit_expr, type, brand)
@@ -49,6 +49,10 @@ impl Parse for ValueMacroInput {
 
 impl ValueMacroInput {
     pub fn expand(self) -> TokenStream {
+        if let Some(error) = validate_known_units(&self.unit_expr) {
+            return error;
+        }
+
         // Generate documentation structs for unit identifiers
         // For value! macro, use storage type for affine/nonstorage units (like quantity!)
         let doc_structs = generate_unit_documentation_for_expr(&self.unit_expr, true);

--- a/tests/compile_fail_cge/quantity_unknown_unit.rs
+++ b/tests/compile_fail_cge/quantity_unknown_unit.rs
@@ -1,0 +1,5 @@
+use whippyunits::quantity;
+
+fn main() {
+    let _x = quantity!(5.0, xyz);
+}

--- a/tests/compile_fail_cge/quantity_unknown_unit.stderr
+++ b/tests/compile_fail_cge/quantity_unknown_unit.stderr
@@ -1,0 +1,15 @@
+error: macro expansion ignores `;` and any tokens following
+ --> tests/compile_fail_cge/quantity_unknown_unit.rs:4:14
+  |
+4 |     let _x = quantity!(5.0, xyz);
+  |              ^^^^^^^^^^^^^^^^^^^ caused by the macro expansion here
+  |
+  = note: the usage of `quantity!` is likely invalid in expression context
+
+error: Unknown unit 'xyz'. No similar units found.
+ --> tests/compile_fail_cge/quantity_unknown_unit.rs:4:14
+  |
+4 |     let _x = quantity!(5.0, xyz);
+  |              ^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `quantity` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile_fail_cge/unit_unknown_unit.rs
+++ b/tests/compile_fail_cge/unit_unknown_unit.rs
@@ -1,0 +1,5 @@
+use whippyunits::unit;
+
+fn main() {
+    let _x: unit!(xyz) = todo!();
+}

--- a/tests/compile_fail_cge/unit_unknown_unit.stderr
+++ b/tests/compile_fail_cge/unit_unknown_unit.stderr
@@ -1,0 +1,15 @@
+error: macro expansion ignores `;` and any tokens following
+ --> tests/compile_fail_cge/unit_unknown_unit.rs:4:13
+  |
+4 |     let _x: unit!(xyz) = todo!();
+  |             ^^^^^^^^^^ caused by the macro expansion here
+  |
+  = note: the usage of `unit!` is likely invalid in type context
+
+error: Unknown unit 'xyz'. No similar units found.
+ --> tests/compile_fail_cge/unit_unknown_unit.rs:4:13
+  |
+4 |     let _x: unit!(xyz) = todo!();
+  |             ^^^^^^^^^^
+  |
+  = note: this error originates in the macro `unit` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile_fail_cge/value_unknown_unit.rs
+++ b/tests/compile_fail_cge/value_unknown_unit.rs
@@ -1,0 +1,7 @@
+use whippyunits::quantity;
+use whippyunits::value;
+
+fn main() {
+    let distance = quantity!(5.0, m);
+    let _x: f64 = value!(distance, xyz);
+}

--- a/tests/compile_fail_cge/value_unknown_unit.stderr
+++ b/tests/compile_fail_cge/value_unknown_unit.stderr
@@ -1,0 +1,15 @@
+error: macro expansion ignores `;` and any tokens following
+ --> tests/compile_fail_cge/value_unknown_unit.rs:6:19
+  |
+6 |     let _x: f64 = value!(distance, xyz);
+  |                   ^^^^^^^^^^^^^^^^^^^^^ caused by the macro expansion here
+  |
+  = note: the usage of `value!` is likely invalid in expression context
+
+error: Unknown unit 'xyz'. No similar units found.
+ --> tests/compile_fail_cge/value_unknown_unit.rs:6:19
+  |
+6 |     let _x: f64 = value!(distance, xyz);
+  |                   ^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `value` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile_fail_stable/quantity_unknown_unit.rs
+++ b/tests/compile_fail_stable/quantity_unknown_unit.rs
@@ -1,0 +1,5 @@
+use whippyunits::quantity;
+
+fn main() {
+    let _x = quantity!(5.0, xyz);
+}

--- a/tests/compile_fail_stable/quantity_unknown_unit.stderr
+++ b/tests/compile_fail_stable/quantity_unknown_unit.stderr
@@ -1,0 +1,15 @@
+error: macro expansion ignores `;` and any tokens following
+ --> tests/compile_fail_stable/quantity_unknown_unit.rs:4:14
+  |
+4 |     let _x = quantity!(5.0, xyz);
+  |              ^^^^^^^^^^^^^^^^^^^ caused by the macro expansion here
+  |
+  = note: the usage of `quantity!` is likely invalid in expression context
+
+error: Unknown unit 'xyz'. No similar units found.
+ --> tests/compile_fail_stable/quantity_unknown_unit.rs:4:14
+  |
+4 |     let _x = quantity!(5.0, xyz);
+  |              ^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `quantity` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile_fail_stable/unit_unknown_unit.rs
+++ b/tests/compile_fail_stable/unit_unknown_unit.rs
@@ -1,0 +1,5 @@
+use whippyunits::unit;
+
+fn main() {
+    let _x: unit!(xyz) = todo!();
+}

--- a/tests/compile_fail_stable/unit_unknown_unit.stderr
+++ b/tests/compile_fail_stable/unit_unknown_unit.stderr
@@ -1,0 +1,15 @@
+error: macro expansion ignores `;` and any tokens following
+ --> tests/compile_fail_stable/unit_unknown_unit.rs:4:13
+  |
+4 |     let _x: unit!(xyz) = todo!();
+  |             ^^^^^^^^^^ caused by the macro expansion here
+  |
+  = note: the usage of `unit!` is likely invalid in type context
+
+error: Unknown unit 'xyz'. No similar units found.
+ --> tests/compile_fail_stable/unit_unknown_unit.rs:4:13
+  |
+4 |     let _x: unit!(xyz) = todo!();
+  |             ^^^^^^^^^^
+  |
+  = note: this error originates in the macro `unit` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile_fail_stable/value_unknown_unit.rs
+++ b/tests/compile_fail_stable/value_unknown_unit.rs
@@ -1,0 +1,7 @@
+use whippyunits::quantity;
+use whippyunits::value;
+
+fn main() {
+    let distance = quantity!(5.0, m);
+    let _x: f64 = value!(distance, xyz);
+}

--- a/tests/compile_fail_stable/value_unknown_unit.stderr
+++ b/tests/compile_fail_stable/value_unknown_unit.stderr
@@ -1,0 +1,15 @@
+error: macro expansion ignores `;` and any tokens following
+ --> tests/compile_fail_stable/value_unknown_unit.rs:6:19
+  |
+6 |     let _x: f64 = value!(distance, xyz);
+  |                   ^^^^^^^^^^^^^^^^^^^^^ caused by the macro expansion here
+  |
+  = note: the usage of `value!` is likely invalid in expression context
+
+error: Unknown unit 'xyz'. No similar units found.
+ --> tests/compile_fail_stable/value_unknown_unit.rs:6:19
+  |
+6 |     let _x: f64 = value!(distance, xyz);
+  |                   ^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `value` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/whippyunits-core/src/units.rs
+++ b/whippyunits-core/src/units.rs
@@ -508,7 +508,7 @@ impl Unit<crate::dimension_exponents!([0, 0, 1, 0, 0, 0, 0, 0])> {
 impl Unit<crate::dimension_exponents!([0, 0, 0, 1, 0, 0, 0, 0])> {
     pub const AMPERE: Self = Self {
         name: "ampere",
-        symbols: &["A"],
+        symbols: &["A", "amp"],
         scale: ScaleExponents::IDENTITY,
         conversion_factor: IDENTITY,
         affine_offset: NONE,


### PR DESCRIPTION
fixes https://github.com/WhippyUnits/whippyunits-rs/issues/10, https://github.com/WhippyUnits/whippyunits-rs/issues/11